### PR TITLE
depreciation(name): Fix region check for S3 bucket in forwarder.tf

### DIFF
--- a/modules/forwarder/forwarder.tf
+++ b/modules/forwarder/forwarder.tf
@@ -1,5 +1,5 @@
 resource "aws_lambda_function" "forwarder" {
-  s3_bucket     = data.aws_region.current.name == "us-east-1" ? var.lambda_zip_bucket : "${var.lambda_zip_bucket}-${data.aws_region.current.name}"
+  s3_bucket     = data.aws_region.current.region == "us-east-1" ? var.lambda_zip_bucket : "${var.lambda_zip_bucket}-${data.aws_region.current.region}"
   s3_key        = "axiom-cloudwatch-forwarder/v${var.lambda_zip_version}/forwarder.zip"
   function_name = "${var.prefix}-forwarder"
   logging_config {


### PR DESCRIPTION
Any plans currently run referencing the forwarder module will output this warning:

```
╷
│ Warning: Deprecated attribute
│
│   on .terraform/modules/forwarders/modules/forwarder/forwarder.tf line 2, in resource "aws_lambda_function" "forwarder":
│    2:   s3_bucket     = data.aws_region.current.name == "us-east-1" ? var.lambda_zip_bucket : "${var.lambda_zip_bucket}-${data.aws_region.current.name}"
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
│
│ (and 13 more similar warnings elsewhere)

```
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region#name-1 shows the fix, use region instead. 