### PR TITLE
Add data_tags variable to forwarder module

### DIFF
--- a/modules/forwarder/forwarder.tf
+++ b/modules/forwarder/forwarder.tf
@@ -15,6 +15,7 @@ resource "aws_lambda_function" "forwarder" {
       AXIOM_TOKEN   = var.axiom_token
       AXIOM_DATASET = var.axiom_dataset
       AXIOM_URL     = var.axiom_url
+      DATA_TAGS     = var.data_tags
     }
   }
 

--- a/modules/forwarder/forwarder.tf
+++ b/modules/forwarder/forwarder.tf
@@ -15,7 +15,7 @@ resource "aws_lambda_function" "forwarder" {
       AXIOM_TOKEN   = var.axiom_token
       AXIOM_DATASET = var.axiom_dataset
       AXIOM_URL     = var.axiom_url
-      DATA_TAGS     = var.data_tags
+      DATA_TAGS     = join(",", [for k, v in var.data_tags : "${k}=${v}"])
     }
   }
 

--- a/modules/forwarder/variables.tf
+++ b/modules/forwarder/variables.tf
@@ -38,3 +38,9 @@ variable "cloudwatch_log_retention" {
   default     = 1
 }
 
+variable "data_tags" {
+  type        = string
+  description = "Custom tags to add to all logs forwarded to Axiom (format: key1=value1,key2=value2)"
+  default     = ""
+}
+

--- a/modules/forwarder/variables.tf
+++ b/modules/forwarder/variables.tf
@@ -39,8 +39,8 @@ variable "cloudwatch_log_retention" {
 }
 
 variable "data_tags" {
-  type        = string
-  description = "Custom tags to add to all logs forwarded to Axiom (format: key1=value1,key2=value2)"
-  default     = ""
+  type        = map(string)
+  description = "Custom tags to add to all logs forwarded to Axiom"
+  default     = {}
 }
 


### PR DESCRIPTION
Expose the DATA_TAGS environment variable in the Terraform module, allowing users to add custom tags to all forwarded logs.

Tags appear under aws.tags.* in the log events sent to Axiom.

Usage:
  module "forwarder" {
    source     = "axiomhq/axiom-cloudwatch-forwarder/aws//modules/forwarder"
    data_tags  = "environment=production,application=my-app,owner=platform-team"
    ...
  }

Ref: https://github.com/axiomhq/axiom-cloudwatch-forwarder/blob/main/src/forwarder.py#L46