### PR TITLE
Add axiom_edge and axiom_edge_url variables, bump Lambda to v1.3.0

### DIFF
--- a/modules/forwarder/forwarder.tf
+++ b/modules/forwarder/forwarder.tf
@@ -12,10 +12,12 @@ resource "aws_lambda_function" "forwarder" {
 
   environment {
     variables = {
-      AXIOM_TOKEN   = var.axiom_token
-      AXIOM_DATASET = var.axiom_dataset
-      AXIOM_URL     = var.axiom_url
-      DATA_TAGS     = join(",", [for k, v in var.data_tags : "${k}=${v}"])
+      AXIOM_TOKEN    = var.axiom_token
+      AXIOM_DATASET  = var.axiom_dataset
+      AXIOM_URL      = var.axiom_url
+      AXIOM_EDGE     = var.axiom_edge
+      AXIOM_EDGE_URL = var.axiom_edge_url
+      DATA_TAGS      = join(",", [for k, v in var.data_tags : "${k}=${v}"])
     }
   }
 

--- a/modules/forwarder/variables.tf
+++ b/modules/forwarder/variables.tf
@@ -13,7 +13,7 @@ variable "lambda_zip_bucket" {
 variable "lambda_zip_version" {
   type        = string
   description = "Version of the Axiom Lambda"
-  default     = "1.2.0"
+  default     = "1.3.0"
 }
 
 variable "axiom_dataset" {
@@ -30,6 +30,18 @@ variable "axiom_url" {
   type        = string
   description = "Axiom's API URL"
   default     = "https://api.axiom.co"
+}
+
+variable "axiom_edge" {
+  type        = string
+  description = "Regional edge domain for ingestion (e.g., eu-central-1.aws.edge.axiom.co). When set, data is sent to https://{edge}/v1/ingest/{dataset}."
+  default     = ""
+}
+
+variable "axiom_edge_url" {
+  type        = string
+  description = "Explicit edge URL for ingest operations. If a path is provided, the URL is used as-is. If no path is provided, /v1/ingest/{dataset} is appended. Takes precedence over axiom_edge."
+  default     = ""
 }
 
 variable "cloudwatch_log_retention" {


### PR DESCRIPTION
The Terraform module was missing edge configuration variables needed for EU region deployments and the default Lambda version was stuck at 1.2.0 which predates EU support.