### PR TITLE
Add data_message_key variable to forwarder module

### DIFF
--- a/modules/forwarder/forwarder.tf
+++ b/modules/forwarder/forwarder.tf
@@ -12,10 +12,11 @@ resource "aws_lambda_function" "forwarder" {
 
   environment {
     variables = {
-      AXIOM_TOKEN   = var.axiom_token
-      AXIOM_DATASET = var.axiom_dataset
-      AXIOM_URL     = var.axiom_url
-      DATA_TAGS     = join(",", [for k, v in var.data_tags : "${k}=${v}"])
+      AXIOM_TOKEN      = var.axiom_token
+      AXIOM_DATASET    = var.axiom_dataset
+      AXIOM_URL        = var.axiom_url
+      DATA_TAGS        = join(",", [for k, v in var.data_tags : "${k}=${v}"])
+      DATA_MESSAGE_KEY = var.data_message_key
     }
   }
 

--- a/modules/forwarder/variables.tf
+++ b/modules/forwarder/variables.tf
@@ -44,3 +44,9 @@ variable "data_tags" {
   default     = {}
 }
 
+variable "data_message_key" {
+  type        = string
+  description = "Key to use as the top-level prefix for parsed log fields. Overrides the auto-detected service name (e.g., set to 'app' to get app.level, app.msg instead of unknown.level)."
+  default     = ""
+}
+


### PR DESCRIPTION
Expose DATA_MESSAGE_KEY as a Terraform input variable so users can configure the top-level prefix for parsed log fields without manually editing Lambda environment variables. The Lambda forwarder already reads this env var (forwarder.py) but it was not wired through the Terraform module, forcing users to set it outside of IaC.